### PR TITLE
Fix test for default config

### DIFF
--- a/tests/args.rs
+++ b/tests/args.rs
@@ -57,7 +57,11 @@ fn negative_coordinates() {
 
 #[test]
 fn no_arg() {
-    create_cmd().arg("-c").assert().failure();
+    Command::cargo_bin(APP_NAME)
+        .unwrap()
+        .arg("-c")
+        .assert()
+        .failure();
 }
 
 #[test]

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -6,7 +6,9 @@ pub const WEDDER_WEATHER_API_KEY: &str = "WEDDER_WEATHER_API_KEY";
 
 pub fn create_cmd() -> Command {
     let mut cmd = Command::cargo_bin(APP_NAME).unwrap();
-    cmd.arg("-k")
+    cmd.arg("-c")
+        .arg("")
+        .arg("-k")
         .arg("mock")
         .arg("-w")
         .arg("OpenWeatherMap")

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -4,12 +4,7 @@ mod common;
 
 #[test]
 fn default() {
-    create_cmd()
-        .arg("-c")
-        .arg("")
-        .assert()
-        .success()
-        .stdout(" 2°C\n");
+    create_cmd().assert().success().stdout(" 2°C\n");
 }
 
 #[test]

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -4,7 +4,12 @@ mod common;
 
 #[test]
 fn default() {
-    create_cmd().assert().success().stdout(" 2°C\n");
+    create_cmd()
+        .arg("-c")
+        .arg("")
+        .assert()
+        .success()
+        .stdout(" 2°C\n");
 }
 
 #[test]


### PR DESCRIPTION
If you already have a customized config lying around, that test will use it - and thus not work anymore. To avoid this, we'll use a non-existing config file instead.